### PR TITLE
Save CountBenchQA in .csv in the outputs folder

### DIFF
--- a/vlmeval/dataset/image_vqa.py
+++ b/vlmeval/dataset/image_vqa.py
@@ -2306,6 +2306,10 @@ class CountBenchQA(ImageVQADataset):
             if ans in pred:
                 correct_count += 1
         accuracy = correct_count / total_count if total_count > 0 else 0
+        result_file = eval_file.replace(f".{eval_file.split('.')[-1]}", "_acc.csv")
+        result_df = pd.DataFrame([{"accuracy": accuracy}])
+        dump(result_df, result_file)
+    
         return {'accuracy': accuracy}
 
 

--- a/vlmeval/dataset/image_vqa.py
+++ b/vlmeval/dataset/image_vqa.py
@@ -2307,10 +2307,11 @@ class CountBenchQA(ImageVQADataset):
                 correct_count += 1
         accuracy = correct_count / total_count if total_count > 0 else 0
         result_file = eval_file.replace(f".{eval_file.split('.')[-1]}", "_acc.csv")
-        result_df = pd.DataFrame([{"accuracy": accuracy}])
+        result_dict = {'accuracy': accuracy}
+        result_df = pd.DataFrame([result_dict])
         dump(result_df, result_file)
     
-        return {'accuracy': accuracy}
+        return result_dict
 
 
 class OCR_Reasoning(ImageBaseDataset):


### PR DESCRIPTION
## What does this PR do?
We change the behavior of CountBenchQA such that it saves the results in .csv.

## Tests

- [x] Ran only CountBenchQA
- [x] Ran with other evals

**Environments**
- [x] Tested on single GPU
- [x] Tested on 2x3090
